### PR TITLE
docs(readme): add comparison table and improve npm discoverability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## [1.2.10] – 2026-05-27
+## [1.2.11] – 2026-05-29
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ All notable changes to this project will be documented in this file.
 - Rewrote `README.md`: added npm/license badges, setup with `defaultDbName`, ~20 functions documented with examples, remaining ~30 listed with signatures, organized by category (Insert, Find, Pagination, Update, Delete, Aggregation, Population, ND\_, Other), added "Important Notes" section.
 - Added JSDoc to `MongoDBConnectionManager` class.
 - Cleaned duplicate comment in `mongoDBConnectionManager.js` `isConnected()`.
+- Added "Why use this instead of Mongoose?" comparison table to `README.md`.
+- Improved `package.json` description and keywords for npm search discoverability.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,24 @@
 
 > A simple MongoDB wrapper library for common database operations using the `mongodb` 4.x Node.js driver.
 
+## Why use this instead of Mongoose?
+
+| | **mongoclienteasywrapper** | **Mongoose** | **Native Driver** |
+|---|---|---|---|
+| **Schemas required** | No | Yes | No |
+| **Dependencies** | 1 (`mongodb`) | 20+ | 0 (it is the driver) |
+| **Learning curve** | Minimal | Moderate | Low but verbose |
+| **Auto ObjectId conversion** | Yes | Yes | Manual |
+| **Auto date conversion** | Yes | Via schema types | Manual |
+| **Soft-delete built-in** | Yes (`ND_` functions) | Via plugin | Manual |
+| **Population without models** | Yes (auto-inferred) | Yes (schema refs) | Manual `$lookup` |
+| **Connection management** | Automatic singleton | Automatic | Manual |
+| **Boilerplate per operation** | 1 line | 1-2 lines | 5-6 lines |
+
+**Choose this library when** you want the flexibility of the native driver without the repetitive boilerplate, and you don't need schema validation or middleware. One dependency, zero configuration, just call functions.
+
+**Choose Mongoose when** you need strict schema validation, middleware hooks, virtuals, or a large ecosystem of plugins.
+
 ## Installation
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoclienteasywrapper",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "Lightweight MongoDB wrapper — simplified CRUD, aggregation, pagination, and population with automatic ObjectId/Date conversion and zero schemas",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "1.2.10",
   "description": "Lightweight MongoDB wrapper — simplified CRUD, aggregation, pagination, and population with automatic ObjectId/Date conversion and zero schemas",
   "main": "index.js",
+  "files": [
+    "index.js",
+    "mongoDBConnectionManager.js",
+    "utils/convertId.js",
+    "utils/convertDatetime.js"
+  ],
   "scripts": {
     "test": "node ./test/test.js"
   },
@@ -48,6 +54,9 @@
     "url": "https://github.com/AlbertoMOKnesys/mongoclienteasywrapper/issues"
   },
   "homepage": "https://github.com/AlbertoMOKnesys/mongoclienteasywrapper#readme",
+  "engines": {
+    "node": ">=14.0.0"
+  },
   "dependencies": {
     "mongodb": "4.17.2"
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mongoclienteasywrapper",
   "version": "1.2.10",
-  "description": "Easy wrapper for mongoclient",
+  "description": "Lightweight MongoDB wrapper — simplified CRUD, aggregation, pagination, and population with automatic ObjectId/Date conversion and zero schemas",
   "main": "index.js",
   "scripts": {
     "test": "node ./test/test.js"
@@ -11,17 +11,20 @@
     "url": "git+https://github.com/AlbertoMOKnesys/mongoclienteasywrapper.git"
   },
   "keywords": [
-    "mongo",
     "mongodb",
-    "client",
-    "easy",
-    "wrapper",
-    "database",
-    "nosql",
-    "node",
+    "mongo",
     "mongoclient",
-    "mongo client",
-    "mongo client easy wrapper"
+    "wrapper",
+    "crud",
+    "aggregation",
+    "pagination",
+    "populate",
+    "nosql",
+    "database",
+    "lightweight",
+    "schemaless",
+    "objectid",
+    "lookup"
   ],
   "author": "Alberto Martinez, Christopher Taylor Gonzalez, Gustavo Luna, Jose Tello",
   "contributors": [


### PR DESCRIPTION
Add "Why use this instead of Mongoose?" table comparing features with
Mongoose and the native driver. Rewrite package.json description and
keywords to improve npm search ranking (remove multi-word keywords,
add relevant single-word terms like crud, aggregation, pagination).
Limit npm publish to essential files only (index.js, connection manager,
utils). Add Node.js >= 14 engine requirement.